### PR TITLE
Fix: Resolve document creation 502/403 errors after PR #55

### DIFF
--- a/app/components/DocumentCopy.tsx
+++ b/app/components/DocumentCopy.tsx
@@ -25,7 +25,6 @@ function DocumentCopy({ document, onSubmit }: Props) {
   const { t } = useTranslation();
   const { policies } = useStores();
   const collectionTrees = useCollectionTrees();
-  const [publish, setPublish] = React.useState<boolean>(!!document.publishedAt);
   const [recursive, setRecursive] = React.useState<boolean>(true);
   const [selectedPath, selectPath] = React.useState<NavigationNode | null>(
     null
@@ -54,7 +53,6 @@ function DocumentCopy({ document, onSubmit }: Props) {
 
     try {
       const result = await document.duplicate({
-        publish,
         recursive,
         title: document.title,
         collectionId: selectedPath.collectionId,
@@ -81,17 +79,6 @@ function DocumentCopy({ document, onSubmit }: Props) {
       <OptionsContainer>
         {!document.isTemplate && (
           <>
-            {document.collectionId && (
-              <Text size="small">
-                <Switch
-                  name="publish"
-                  label={t("Publish")}
-                  labelPosition="right"
-                  checked={publish}
-                  onChange={setPublish}
-                />
-              </Text>
-            )}
             {document.publishedAt && document.childDocuments.length > 0 && (
               <Text size="small">
                 <Switch

--- a/app/components/Sidebar/components/CollectionLink.tsx
+++ b/app/components/Sidebar/components/CollectionLink.tsx
@@ -95,8 +95,8 @@ const CollectionLink: React.FC<Props> = ({
           title: input,
           fullWidth: user.getPreference(UserPreference.FullWidthDocuments),
           data: ProsemirrorHelper.getEmptyDocument(),
-        },
-        { publish: true }
+        }
+        // Removed publish parameter - documents are now always visible by default (PR #55)
       );
       collection?.addDocument(newDocument);
 

--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -280,8 +280,8 @@ function InnerDocumentLink(
             user.getPreference(UserPreference.FullWidthDocuments),
           title: input,
           data: ProsemirrorHelper.getEmptyDocument(),
-        },
-        { publish: true }
+        }
+        // Removed publish parameter - documents are now always visible by default (PR #55)
       );
       collection?.addDocument(newDocument, node.id);
 

--- a/app/components/Sidebar/hooks/useDragAndDrop.tsx
+++ b/app/components/Sidebar/hooks/useDragAndDrop.tsx
@@ -589,9 +589,10 @@ export function useDropToArchive() {
   });
 }
 
+// Unpublish functionality removed - documents are now always visible by default (PR #55)
 export function useDropToUnpublish() {
-  const { t } = useTranslation();
-  const { policies, documents } = useStores();
+  // const { t } = useTranslation();
+  // const { policies, documents } = useStores();
 
   return useDrop<
     DragObject,
@@ -599,34 +600,11 @@ export function useDropToUnpublish() {
     { isOver: boolean; canDrop: boolean }
   >({
     accept: "document",
-    drop: async (item) => {
-      const document = documents.get(item.id);
-      if (!document) {
-        return;
-      }
-
-      try {
-        await document.unpublish({ detach: true });
-        toast.success(
-          t("Unpublished {{ documentName }}", {
-            documentName: document.noun,
-          })
-        );
-      } catch (err) {
-        toast.error(err.message);
-      }
-    },
-    canDrop: (item) => {
-      const policy = policies.abilities(item.id);
-      if (!policy) {
-        return true; // optimistic, let the server check for the necessary permission.
-      }
-
-      return policy.unpublish;
-    },
-    collect: (monitor) => ({
-      isOver: monitor.isOver(),
-      canDrop: monitor.canDrop(),
+    drop: async (_item) => undefined,
+    canDrop: (_item) => false,
+    collect: (_monitor) => ({
+      isOver: false, // Never show hover state since this is disabled
+      canDrop: false, // Never allow drop since this is disabled
     }),
   });
 }

--- a/app/components/TemplatizeDialog/index.tsx
+++ b/app/components/TemplatizeDialog/index.tsx
@@ -6,7 +6,6 @@ import { useHistory } from "react-router-dom";
 import { toast } from "sonner";
 import ConfirmationDialog from "~/components/ConfirmationDialog";
 import Flex from "~/components/Flex";
-import Switch from "~/components/Switch";
 import useStores from "~/hooks/useStores";
 import { documentPath } from "~/utils/routeHelpers";
 import SelectLocation from "./SelectLocation";
@@ -22,7 +21,6 @@ function DocumentTemplatizeDialog({ documentId }: Props) {
   const document = documents.get(documentId);
   invariant(document, "Document must exist");
 
-  const [publish, setPublish] = React.useState(true);
   const [collectionId, setCollectionId] = React.useState(
     document.collectionId ?? null
   );
@@ -30,13 +28,12 @@ function DocumentTemplatizeDialog({ documentId }: Props) {
   const handleSubmit = React.useCallback(async () => {
     const template = await document?.templatize({
       collectionId,
-      publish,
     });
     if (template) {
       history.push(documentPath(template));
       toast.success(t("Template created, go ahead and customize it"));
     }
-  }, [t, document, history, collectionId, publish]);
+  }, [t, document, history, collectionId]);
 
   return (
     <ConfirmationDialog
@@ -59,13 +56,6 @@ function DocumentTemplatizeDialog({ documentId }: Props) {
         <SelectLocation
           defaultCollectionId={collectionId}
           onSelect={setCollectionId}
-        />
-        <Switch
-          name="publish"
-          label={t("Published")}
-          note={t("Enable other members to use the template immediately")}
-          checked={publish}
-          onChange={setPublish}
         />
       </Flex>
     </ConfirmationDialog>

--- a/app/hooks/useImportDocument.ts
+++ b/app/hooks/useImportDocument.ts
@@ -46,9 +46,12 @@ export default function useImportDocument(
 
         for (const file of files) {
           try {
-            const doc = await documents.import(file, documentId, cId, {
-              publish: true,
-            });
+            const doc = await documents.import(
+              file,
+              documentId,
+              cId,
+              {} // Empty options - documents are now always visible by default (PR #55)
+            );
 
             if (redirect) {
               history.push(documentPath(doc));

--- a/app/menus/CollectionMenu.tsx
+++ b/app/menus/CollectionMenu.tsx
@@ -139,9 +139,12 @@ function CollectionMenu({
 
       try {
         const file = files[0];
-        const document = await documents.import(file, null, collection.id, {
-          publish: true,
-        });
+        const document = await documents.import(
+          file,
+          null,
+          collection.id,
+          {} // Empty options - documents are now always visible by default (PR #55)
+        );
         history.push(document.url);
       } catch (err) {
         toast.error(err.message);

--- a/app/menus/DocumentMenu.tsx
+++ b/app/menus/DocumentMenu.tsx
@@ -460,9 +460,7 @@ function DocumentMenu({
           file,
           document.id,
           collection.id,
-          {
-            publish: true,
-          }
+          {} // Empty options - documents are now always visible by default (PR #55)
         );
         history.push(importedDocument.url);
       } catch (err) {

--- a/app/scenes/Collection/components/Overview.tsx
+++ b/app/scenes/Collection/components/Overview.tsx
@@ -64,10 +64,8 @@ function Overview({ collection }: Props) {
           collectionId: collection.id,
           data: ProsemirrorHelper.getEmptyDocument(),
           ...params,
-        },
-        {
-          publish: true,
         }
+        // Removed publish parameter - documents are now always visible by default (PR #55)
       );
 
       return newDocument.url;

--- a/app/scenes/Document/components/DataLoader.tsx
+++ b/app/scenes/Document/components/DataLoader.tsx
@@ -161,10 +161,8 @@ function DataLoader({ match, children }: Props) {
           parentDocumentId: nested ? document.id : document.parentDocumentId,
           data: ProsemirrorHelper.getEmptyDocument(),
           ...params,
-        },
-        {
-          publish: document.isDraft ? undefined : true,
         }
+        // Removed publish parameter - documents are now always visible by default (PR #55)
       );
 
       return newDocument.url;

--- a/app/scenes/DocumentNew.tsx
+++ b/app/scenes/DocumentNew.tsx
@@ -51,8 +51,8 @@ function DocumentNew({ template }: Props) {
             template,
             title: query.get("title") ?? "",
             data: ProsemirrorHelper.getEmptyDocument(),
-          },
-          { publish: collection?.id || parentDocumentId ? true : undefined }
+          }
+          // Removed publish parameter - documents are now always visible by default (PR #55)
         );
 
         history.replace(

--- a/server/commands/accountProvisioner.ts
+++ b/server/commands/accountProvisioner.ts
@@ -245,11 +245,12 @@ async function provisionFirstCollection(team: Team, user: User) {
       );
 
       document.content = await DocumentHelper.toJSON(document);
-
-      await document.publish(user, collection.id, {
-        silent: true,
-        transaction,
-      });
+      
+      // Documents are now published by default, no need for explicit publish
+      await document.save({ transaction });
+      
+      // Add document to collection structure
+      await collection.addDocumentToStructure(document, 0, { transaction });
     }
   });
 }

--- a/server/commands/documentCreator.test.ts
+++ b/server/commands/documentCreator.test.ts
@@ -132,7 +132,7 @@ describe("documentCreator", () => {
       expect(document.fullWidth).toBe(true);
     });
 
-    it("should create document as draft when publish is false", async () => {
+    it("should create document as draft when publishedAt is null", async () => {
       const user = await buildUser();
       const collection = await buildCollection({
         userId: user.id,
@@ -144,7 +144,7 @@ describe("documentCreator", () => {
           title: "Draft Document",
           text: "Draft content",
           collectionId: collection.id,
-          publish: false,
+          publishedAt: null,
           user,
           ctx,
         })
@@ -153,7 +153,7 @@ describe("documentCreator", () => {
       expect(document.publishedAt).toBeNull();
     });
 
-    it("should publish document when publish is true", async () => {
+    it("should publish document when publishedAt is set", async () => {
       const user = await buildUser();
       const collection = await buildCollection({
         userId: user.id,
@@ -165,7 +165,7 @@ describe("documentCreator", () => {
           title: "Published Document",
           text: "Published content",
           collectionId: collection.id,
-          publish: true,
+          publishedAt: new Date(),
           user,
           ctx,
         })
@@ -182,7 +182,7 @@ describe("documentCreator", () => {
           documentCreator({
             title: "Invalid Document",
             text: "Content",
-            publish: true,
+            publishedAt: new Date(),
             user,
             ctx,
           })

--- a/server/commands/documentCreator.ts
+++ b/server/commands/documentCreator.ts
@@ -126,6 +126,7 @@ export default async function documentCreator({
     title: titleWithReplacements,
     content: contentWithReplacements,
     state,
+    insightsEnabled: true, // Default to true to allow viewing insights
   });
 
   document.text = DocumentHelper.toMarkdown(document, {

--- a/server/commands/documentDuplicator.test.ts
+++ b/server/commands/documentDuplicator.test.ts
@@ -93,7 +93,7 @@ describe("documentDuplicator", () => {
       documentDuplicator({
         document: original,
         collection: original.collection,
-        publish: false,
+        publishedAt: null,
         user,
         ctx: createContext({ user, transaction }),
       })

--- a/server/commands/documentDuplicator.ts
+++ b/server/commands/documentDuplicator.ts
@@ -16,8 +16,8 @@ type Props = {
   parentDocumentId?: string;
   /** Override of the duplicated document title */
   title?: string;
-  /** Override of the duplicated document publish state */
-  publish?: boolean;
+  /** Override of the duplicated document published date */
+  publishedAt?: Date | null;
   /** Whether to duplicate child documents */
   recursive?: boolean;
   /** The request context */
@@ -30,7 +30,7 @@ export default async function documentDuplicator({
   collection,
   parentDocumentId,
   title,
-  publish,
+  publishedAt,
   recursive,
   ctx,
 }: Props): Promise<Document[]> {
@@ -38,7 +38,7 @@ export default async function documentDuplicator({
   const sharedProperties = {
     user,
     collectionId: collection?.id,
-    publish: publish ?? !!document.publishedAt,
+    publishedAt: publishedAt !== undefined ? publishedAt : (document.publishedAt || new Date()),
     ctx,
   };
 

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -300,6 +300,7 @@ class Document extends ArchivableModel<
   @Column
   fullWidth: boolean;
 
+  @Default(true)
   @Column
   insightsEnabled: boolean;
 

--- a/server/queues/tasks/DocumentImportTask.ts
+++ b/server/queues/tasks/DocumentImportTask.ts
@@ -58,7 +58,7 @@ export default class DocumentImportTask extends BaseTask<Props> {
           icon,
           text,
           state,
-          publish,
+          publishedAt: publish ? new Date() : null,
           collectionId,
           parentDocumentId,
           user,

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -1210,14 +1210,13 @@ router.post(
     const editorVersion = ctx.headers["x-editor-version"] as string | undefined;
 
     const { user } = ctx.state.auth;
-    let collection: Collection | null | undefined;
 
     let document = await Document.findByPk(id, {
       userId: user.id,
       includeState: true,
       transaction,
     });
-    collection = document?.collection;
+    const collection = document?.collection;
     authorize(user, "update", document);
 
     if (collection && insightsEnabled !== undefined) {
@@ -1288,7 +1287,7 @@ router.post(
       collection,
       document,
       title,
-      publish,
+      publishedAt: publish ? new Date() : null,
       recursive,
       parentDocumentId,
       ctx,
@@ -1500,7 +1499,7 @@ router.post(
   validate(T.DocumentsImportSchema),
   multipart({ maximumFileSize: env.FILE_STORAGE_IMPORT_MAX_SIZE }),
   async (ctx: APIContext<T.DocumentsImportReq>) => {
-    const { collectionId, parentDocumentId, publish } = ctx.input.body;
+    const { collectionId, parentDocumentId } = ctx.input.body;
     const file = ctx.input.file;
     const { user } = ctx.state.auth;
 
@@ -1546,7 +1545,7 @@ router.post(
       userId: user.id,
       collectionId,
       parentDocumentId,
-      publish,
+      publish: true, // Documents are now always visible by default (PR #55)
       ip: ctx.request.ip,
     });
     const response: DocumentImportTaskResponse = await job.finished();


### PR DESCRIPTION
## Summary
- Fixes critical document creation issues introduced after PR #55
- Resolves 502 Bad Gateway errors on `/api/documents.create`
- Fixes 403 Forbidden errors on `/api/views.list`

## Problem
After PR #55 (Notion-style permissions) removed the publish/unpublish functionality, several parts of the codebase were still using the old `publish` boolean property instead of the new `publishedAt` date field. This caused:
1. 502 errors when creating documents
2. 403 errors when viewing document analytics
3. TypeScript compilation errors

## Solution
### Backend Changes
- Updated `documentDuplicator` to use `publishedAt` instead of `publish` property
- Fixed test files to match the new API
- Updated document import and duplication endpoints
- Ensured `insightsEnabled` is set to `true` by default

### Frontend Changes  
- Removed `publish` parameter from all document creation calls
- Removed publish toggle UI from DocumentCopy and TemplatizeDialog components
- Fixed import methods to include required empty options object
- Updated drag-and-drop hooks to handle removed unpublish functionality

## Test plan
- [ ] Create a new document - should work without errors
- [ ] Duplicate a document - should work without errors
- [ ] Import a document - should work without errors
- [ ] View document analytics - should work without 403 errors
- [ ] All TypeScript compilation should pass

🤖 Generated with [Claude Code](https://claude.ai/code)